### PR TITLE
Dispatch sink

### DIFF
--- a/fpga/_processor.py
+++ b/fpga/_processor.py
@@ -125,9 +125,6 @@ class Processor(neuro.Processor):
         match self._io_type[2:]:
             case "DO":
                 self._out_type = _IoType.DISPATCH
-                raise NotImplementedError(
-                    "Dispatch output is currently malfunctioning."
-                )
             case "SO":
                 self._out_type = _IoType.STREAM
             case _:

--- a/fpga/rtl/dispatch_sink.sv
+++ b/fpga/rtl/dispatch_sink.sv
@@ -89,7 +89,7 @@ module network_sink (
             if (pop_counter > 0 && ((pop_counter == 1) || pop_fire)) begin
                 // an entry was pushed onto the snk_stack
                 snk_counter <= snk_counter + 1;
-            end esle if (snk_valid && snk_ready) begin
+            end else if (snk_valid && snk_ready) begin
                 // an entry was popped from the snk_stack
                 snk_counter <= snk_counter - 1;
             end

--- a/fpga/rtl/dispatch_sink.sv
+++ b/fpga/rtl/dispatch_sink.sv
@@ -35,46 +35,52 @@ module network_sink (
     // 1. the indices of the net outputs that fired in descending order
     // 2. the number of net outputs that fired
     // of these, 2 is always populated, and the queue is sent out back-to-front
-    logic [$clog2(NET_NUM_OUT + 2)-1:0] snk_counter;
-    logic [$clog2(NET_NUM_OUT + 2)-1:0] next_snk_counter;
     logic [SNK_WIDTH-1:0] snk_queue [0:(NET_NUM_OUT)];   // not -1 because of num_out
-    logic [SNK_WIDTH-1:0] next_snk_queue [0:(NET_NUM_OUT)];
 
-    // FIXME: This logic is not working.
-    // There might not be a way to accomplish single-cycle queue population in synthesizeable code.
-    always_comb begin : calc_next_snk
-        int i = 0;
-        // loop in reverse so we can count down queue positions using snk_counter
-        for (int j = NET_NUM_OUT - 1; j >= 0; j--) begin
-            if (net_out[j]) begin
-                next_snk_queue[i] = j;
-                i++;
+    logic [$clog2(NET_NUM_OUT + 2)-1:0] snk_counter, pop_counter;
+    assign snk_valid = (pop_counter == 0) && (snk_counter > 0);
+    assign net_ready = (pop_counter == 0) && (snk_counter == 0);
+
+    logic pop_fire = net_out[NET_NUM_OUT + 1 - pop_counter];
+
+    always_ff @(posedge clk or negedge arstn) begin: set_pop_counter
+        if (arstn == 0) begin
+            pop_counter <= 0;
+        end else begin
+            if (net_valid && net_ready) begin
+                pop_counter <= NET_NUM_OUT + 1;
+            end else if (pop_counter > 0) begin
+                pop_counter <= pop_counter - 1;
             end
         end
-        next_snk_queue[i] = i;
-        next_snk_counter = i + 1;
     end
 
     always_ff @(posedge clk or negedge arstn) begin: set_snk_queue
         if (arstn == 0) begin
             foreach (snk_queue[i])
                 snk_queue[i] <= 0;
-        end else if (net_valid && net_ready) begin
-            snk_queue <= next_snk_queue;
+        end else begin
+            if (net_valid && net_ready) begin
+                foreach (snk_queue[i])
+                    snk_queue[i] <= 0;
+            end else if (pop_counter > 0) begin
+                if (pop_counter == 1) begin
+                    snk_queue[snk_counter] <= snk_counter;
+                end else if (pop_fire) begin
+                    snk_queue[snk_counter] <= NET_NUM_OUT + 1 - pop_counter;
+                end
+            end
         end
     end
 
-    assign snk_valid = (snk_counter > 0);
-    assign net_ready = (snk_counter == 0);
-
-    always_ff @(posedge clk or negedge arstn) begin : set_snk_counter
+    always_ff @(posedge clk or negedge arstn) begin: set_snk_counter
         if (arstn == 0) begin
             snk_counter <= 0;
         end else begin
-            if (snk_valid && snk_ready) begin
+            if (pop_fire && (pop_counter > 1)) begin
+                snk_counter <= snk_counter + 1;
+            end esle if (snk_valid && snk_ready) begin
                 snk_counter <= snk_counter - 1;
-            end else if (net_valid && net_ready) begin
-                snk_counter <= next_snk_counter;
             end
         end
     end

--- a/fpga/rtl/dispatch_sink.sv
+++ b/fpga/rtl/dispatch_sink.sv
@@ -30,18 +30,21 @@ module network_sink (
     // sink output
     output logic [SNK_WIDTH-1:0] snk
 );
+    logic [NET_NUM_OUT-1:0] fires;
 
-    // the snk_queue is a little bit complicated it holds:
-    // 1. the indices of the net outputs that fired in descending order
-    // 2. the number of net outputs that fired
-    // of these, 2 is always populated, and the queue is sent out back-to-front
-    logic [SNK_WIDTH-1:0] snk_queue [0:(NET_NUM_OUT)];   // not -1 because of num_out
+    always_ff @(posedge clk or negedge arstn) begin: set_fires
+        if (arstn == 0) begin
+            fires <= 0;
+        end else if (net_valid && net_ready) begin
+            fires <= net_out;
+        end
+    end
 
     logic [$clog2(NET_NUM_OUT + 2)-1:0] snk_counter, pop_counter;
     assign snk_valid = (pop_counter == 0) && (snk_counter > 0);
     assign net_ready = (pop_counter == 0) && (snk_counter == 0);
 
-    logic pop_fire = net_out[NET_NUM_OUT + 1 - pop_counter];
+    logic pop_fire = fires[NET_NUM_OUT + 1 - pop_counter];
 
     always_ff @(posedge clk or negedge arstn) begin: set_pop_counter
         if (arstn == 0) begin
@@ -55,19 +58,25 @@ module network_sink (
         end
     end
 
-    always_ff @(posedge clk or negedge arstn) begin: set_snk_queue
+    // the snk_stack is a little bit complicated it holds:
+    // 1. the indices of the net outputs that fired in descending order
+    // 2. the number of net outputs that fired
+    // of these, 2 is always populated
+    logic [SNK_WIDTH-1:0] snk_stack [0:(NET_NUM_OUT)];   // not -1 because of num_out
+
+    always_ff @(posedge clk or negedge arstn) begin: set_snk_stack
         if (arstn == 0) begin
-            foreach (snk_queue[i])
-                snk_queue[i] <= 0;
+            foreach (snk_stack[i])
+                snk_stack[i] <= 0;
         end else begin
             if (net_valid && net_ready) begin
-                foreach (snk_queue[i])
-                    snk_queue[i] <= 0;
+                foreach (snk_stack[i])
+                    snk_stack[i] <= 0;
             end else if (pop_counter > 0) begin
                 if (pop_counter == 1) begin
-                    snk_queue[snk_counter] <= snk_counter;
+                    snk_stack[snk_counter] <= snk_counter;
                 end else if (pop_fire) begin
-                    snk_queue[snk_counter] <= NET_NUM_OUT + 1 - pop_counter;
+                    snk_stack[snk_counter] <= NET_NUM_OUT + 1 - pop_counter;
                 end
             end
         end
@@ -77,14 +86,16 @@ module network_sink (
         if (arstn == 0) begin
             snk_counter <= 0;
         end else begin
-            if (pop_fire && (pop_counter > 1)) begin
+            if (pop_counter > 0 && ((pop_counter == 1) || pop_fire)) begin
+                // an entry was pushed onto the snk_stack
                 snk_counter <= snk_counter + 1;
             end esle if (snk_valid && snk_ready) begin
+                // an entry was popped from the snk_stack
                 snk_counter <= snk_counter - 1;
             end
         end
     end
 
-    assign snk = snk_queue[snk_counter - 1];
+    assign snk = snk_stack[snk_counter - 1];
 
 endmodule


### PR DESCRIPTION
I finally got the logic for dispatch sink (sends the number of output fires followed by the indices which fired) figured out, but it has a substantial compromise. It was not possible to calculate the output queue in a single clock cycle, possibly just because of the sheer number of combinations, but more likely because the dynamic indexing of assignments in a combinational logic block wouldn't be synthesizable.

This means there's an intermediate processing step to populate that array which will always take `NUM_OUT` clock cycles. For an infinitely fast (always ready) sink, this would make the process O(`NUM_OUT` + `num_fires`), which would be awful. Therefore, such a sink should always use `stream_sink`. For an infinitely slow sink (almost never ready), the process would approach O(`num_fires`) which is what we want.

So, the choice of dispatch or stream for slow interfaces still largely reduces down to the density of fires relative to output width and timescale. However any advantage provided by the dispatch sink is inversely proportional to interface speed up to the crossover point.

It may be useful to have some sort of calculation logic in the future which can take interface speed, clock speed, number of output neurons, and estimated number of input spikes and output fires per run to then provide minimum, maximum, and estimated "runs per second" rates for the processor type permutations in a table.

Speaking of, here's how I worked out the logic:

![Dispatch Sink](https://github.com/TENNLab-UTK/fpga/assets/25830144/a5de8ff3-168a-4651-90eb-56867ce348b5)