### PR TITLE
Fix breaking cocotb tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The TENNLab Neuromorphic Framework only works on Unix-like systems. Vivado only 
 
 Install any simulators you wish to use which are [compatible with cocotb](https://docs.cocotb.org/en/stable/simulator_support.html).
 
-**NOTE:** This project uses valid SystemVerilog that is currently incompatible with Icarus (iverilog). As a consequence, we are currently only running testbenches with Verilator. Even there, compatibility between the simulator and cocotb can be fragile, so we are currently using v5.006.
+**NOTE:** This project uses valid SystemVerilog that is currently incompatible with Icarus (iverilog). As a consequence, we are currently only running testbenches with Verilator. Even there, compatibility between the simulator and cocotb can be fragile, so we are currently using v5.024.
 
 If you wish to see waveform outputs from the sims, install gtkwave.
 

--- a/fpga/rtl/dispatch_source.sv
+++ b/fpga/rtl/dispatch_source.sv
@@ -77,8 +77,8 @@ module network_source #(
     else
         assign inp_idx = src[(`SRC_WIDTH - OPC_WIDTH - 1) -: $clog2(NET_NUM_INP)];
 
-    logic signed [NET_CHARGE_WIDTH-1:0] inp_val
-        = src[(`SRC_WIDTH - OPC_WIDTH - $clog2(NET_NUM_INP) - 1) -: NET_CHARGE_WIDTH];
+    logic signed [NET_CHARGE_WIDTH-1:0] inp_val;
+    assign inp_val = src[(`SRC_WIDTH - OPC_WIDTH - $clog2(NET_NUM_INP) - 1) -: NET_CHARGE_WIDTH];
 
     always_ff @(posedge clk or negedge arstn) begin: set_net_inp
         if (arstn == 0 || op == CLR) begin

--- a/fpga/rtl/stream_source.sv
+++ b/fpga/rtl/stream_source.sv
@@ -52,7 +52,9 @@ module network_source #(
         end
     end
 
-    logic net_en = src_valid && net_ready;
+    logic net_en;
+    assign net_en = src_valid && net_ready;
+
     logic was_ready;
 
     always_ff @(posedge clk or negedge arstn) begin: set_was_ready

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "cocotb",
+    "cocotb ~= 1.8.0",
     "cocotb-test",
 ]
 dev = [


### PR DESCRIPTION
This resolves #3 while possible migration away from Verilator is considered.